### PR TITLE
Readme troubleshooting section for examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,21 @@ Apart from the problem, options can be passed to `benchopt run`, to restrict the
 
 Use `benchopt run -h` for more details about these options, or visit https://benchopt.github.io/api.html.
 
+Troubleshooting
+---------------
+
+If you run into some errors when running the examples present in this Readme, try installing the development version of `benchopt`:
+
+.. code-block::
+
+  $ pip install -U git+https://github.com/benchopt/benchopt
+
+If issues persist, you can also try running the benchmark in local mode with the `-l` option, e.g.:
+
+.. code-block::
+
+  $ benchopt run ./benchmark_lasso -l -s sklearn -d boston --max-runs 10 --n-repetitions 10
+
 .. |Build Status| image:: https://github.com/benchopt/benchmark_lasso/workflows/build/badge.svg
    :target: https://github.com/benchopt/benchmark_lasso/actions
 .. |Python 3.6+| image:: https://img.shields.io/badge/python-3.6%2B-blue

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,8 @@ If issues persist, you can also try running the benchmark in local mode with the
 
   $ benchopt run ./benchmark_lasso -l -s sklearn -d boston --max-runs 10 --n-repetitions 10
 
+Note that in this case, only solvers which dependencies are installed in the current env will be run.
+
 .. |Build Status| image:: https://github.com/benchopt/benchmark_lasso/workflows/build/badge.svg
    :target: https://github.com/benchopt/benchmark_lasso/actions
 .. |Python 3.6+| image:: https://img.shields.io/badge/python-3.6%2B-blue


### PR DESCRIPTION
Basically explained how to install `benchopt` from source and how to use the local `-l` option

This partly tackles #5 .