### PR TITLE
FIX: celer does not support max_iter=0

### DIFF
--- a/solvers/celer.py
+++ b/solvers/celer.py
@@ -28,7 +28,7 @@ class Solver(BaseSolver):
         )
 
     def run(self, n_iter):
-        self.lasso.max_iter = n_iter
+        self.lasso.max_iter = n_iter + 1
         self.lasso.fit(self.X, self.y)
 
     def get_result(self):


### PR DESCRIPTION
currently celer does not run because it is passed max_iter = 0 and does not like it. 