### PR TITLE
rm normalize parameter in celer

### DIFF
--- a/solvers/celer.py
+++ b/solvers/celer.py
@@ -31,7 +31,7 @@ class Solver(BaseSolver):
         self.lasso = Lasso(
             alpha=self.lmbd / n_samples, max_iter=1, max_epochs=100000,
             tol=1e-12, prune=True, fit_intercept=fit_intercept,
-            normalize=False, warm_start=False, positive=False, verbose=False,
+            warm_start=False, positive=False, verbose=False,
         )
 
     def run(self, n_iter):


### PR DESCRIPTION
This parameter has been deprecated in sklearn 1.0 and using raises a warning. It's False by default in celer so the solver behaviour is not affected.
```
|----Celer:  26.6% (0 / 1 reps)                                                
 /home/mathurin/workspace/scikit-learn/sklearn/linear_model/_base.py:148: 
FutureWarning: 'normalize' was deprecated in version 1.0 and will be removed in 1.2. 
Please leave the normalize parameter to its default value to silence this warning. 
The default behavior of this estimator is to not do any normalization. 
If normalization is needed please use sklearn.preprocessing.StandardScaler instead.
```