### PR TITLE
rm normalize parameter in celer

### DIFF
--- a/solvers/celer.py
+++ b/solvers/celer.py
@@ -35,7 +35,7 @@ class Solver(BaseSolver):
         )
 
     def run(self, n_iter):
-        self.lasso.max_iter = n_iter + 1
+        self.lasso.max_iter = n_iter
         self.lasso.fit(self.X, self.y)
 
     def get_result(self):

--- a/solvers/celer.py
+++ b/solvers/celer.py
@@ -31,7 +31,7 @@ class Solver(BaseSolver):
         self.lasso = Lasso(
             alpha=self.lmbd / n_samples, max_iter=1, max_epochs=100000,
             tol=1e-12, prune=True, fit_intercept=fit_intercept,
-            normalize=False, warm_start=False, positive=False, verbose=False,
+            warm_start=False, positive=False, verbose=False,
         )
 
     def run(self, n_iter):


### PR DESCRIPTION
It is removed since version 0.6.1 that is now on PyPI (it will be removed in sklearn in 1 or 2 versions too)

should fix the failure in #38 