### PR TITLE
Update blitz source of install to main repo

### DIFF
--- a/solvers/blitz.py
+++ b/solvers/blitz.py
@@ -12,7 +12,7 @@ class Solver(BaseSolver):
 
     install_cmd = 'conda'
     requirements = [
-        'pip:git+https://github.com/tommoral/blitzl1.git@FIX_setup_deps'
+        'pip:git+https://github.com/tbjohns/blitzl1.git@master'
     ]
     references = [
         'T. B. Johnson and C. Guestrin, "Blitz: A Principled Meta-Algorithm '


### PR DESCRIPTION
I have the push rights to tbjohns/blitzl1 so we no longer have to pin the install to a particular branch of yours @tomMoral 

In particular I have a ready to merge PR there where I have implemented an iteration strategy in addition to `ŧol`, so it may be nice to keep up to date with the original repo.