### PR TITLE
Change blitz stopping strategy from tolerance to iteration

### DIFF
--- a/solvers/blitz.py
+++ b/solvers/blitz.py
@@ -30,10 +30,10 @@ class Solver(BaseSolver):
         self.X, self.y, self.lmbd = X, y, lmbd
 
         blitzl1.set_use_intercept(False)
+        blitzl1.set_tolerance(0)
         self.problem = blitzl1.LassoProblem(self.X, self.y)
 
     def run(self, n_iter):
-        blitzl1.set_tolerance(0)
         self.coef_ = self.problem.solve(self.lmbd, max_iter=n_iter).x
 
     def get_result(self):

--- a/solvers/blitz.py
+++ b/solvers/blitz.py
@@ -8,7 +8,7 @@ with safe_import_context() as import_ctx:
 
 class Solver(BaseSolver):
     name = 'Blitz'
-    stop_strategy = 'tolerance'
+    stop_strategy = 'iteration'
 
     install_cmd = 'conda'
     requirements = [
@@ -32,9 +32,9 @@ class Solver(BaseSolver):
         blitzl1.set_use_intercept(False)
         self.problem = blitzl1.LassoProblem(self.X, self.y)
 
-    def run(self, tolerance):
-        blitzl1.set_tolerance(tolerance)
-        self.coef_ = self.problem.solve(self.lmbd).x
+    def run(self, n_iter):
+        blitzl1.set_tolerance(0)
+        self.coef_ = self.problem.solve(self.lmbd, max_iter=n_iter).x
 
     def get_result(self):
         return self.coef_.flatten()


### PR DESCRIPTION
I merged this morning into Blitz master an implementation of `max_iter`.

I think iteration stopping criterion has less non linear effects than tolerance. Let me know what you think.