### PR TITLE
readd lightning to test suite

### DIFF
--- a/solvers/lightning.py
+++ b/solvers/lightning.py
@@ -14,6 +14,7 @@ class Solver(BaseSolver):
 
     install_cmd = 'conda'
     requirements = [
+        'cython',
         'pip:git+https://github.com/scikit-learn-contrib/lightning.git'
     ]
     references = [

--- a/test_config.py
+++ b/test_config.py
@@ -14,12 +14,6 @@ def check_test_solver_install(solver_class):
     if 'julia' in solver_class.name.lower() and sys.platform == 'darwin':
         pytest.xfail('Julia causes segfault on OSX for now.')
 
-    # Lightning install is broken on python3.9+.
-    # See issue scikit-learn-contrib/lightning#153.
-    if (solver_class.name.lower() == 'lightning'
-            and sys.version_info >= (3, 9)):
-        pytest.xfail('Lightning install is broken on python3.9+.')
-
     # ModOpt install change numpy version, breaking celer install.
     # See CEA-COSMIC/ModOpt#144. Skipping for now
     if ('modopt' in solver_class.name.lower()):


### PR DESCRIPTION
It seems that lightning again works with python 3.9

However I need to add cython to its dependencies, as otherwise I get:
```
(test) ➜  lasso git:(xfail_julia) ✗ benchopt install . -s lightning
Installing 'lasso' requirements
Install in the current env 'test'? [y/N]: y
# Install
Collecting packages:
- 'leukemia' already available
- 'Simulated' already available
... done
Installing required packages for:
- Lightning
- finance
- libsvm
...Collecting git+https://github.com/scikit-learn-contrib/lightning.git
  Cloning https://github.com/scikit-learn-contrib/lightning.git to /tmp/pip-req-build-7gox6ycx
  Running command git clone -q https://github.com/scikit-learn-contrib/lightning.git /tmp/pip-req-build-7gox6ycx
  Resolved https://github.com/scikit-learn-contrib/lightning.git to commit 6e9afffd667ca2180b090bcfcf12d5ab45ba4042
    ERROR: Command errored out with exit status 1:
     command: /home/mathurin/anaconda3/envs/test/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-7gox6ycx/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-7gox6ycx/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-0g4g3vkh
         cwd: /tmp/pip-req-build-7gox6ycx/
    Complete output (26 lines):
    Traceback (most recent call last):
      File "lightning/setup.py", line 9, in cythonize_extensions
        from Cython.Build import cythonize
    ModuleNotFoundError: No module named 'Cython'
    
    The above exception was the direct cause of the following exception:
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-7gox6ycx/setup.py", line 63, in <module>
        setup(configuration=configuration,
      File "/home/mathurin/anaconda3/envs/test/lib/python3.9/site-packages/numpy/distutils/core.py", line 135, in setup
        config = configuration()
      File "/tmp/pip-req-build-7gox6ycx/setup.py", line 51, in configuration
        config.add_subpackage('lightning')
      File "/home/mathurin/anaconda3/envs/test/lib/python3.9/site-packages/numpy/distutils/misc_util.py", line 1016, in add_subpackage
        config_list = self.get_subpackage(subpackage_name, subpackage_path,
      File "/home/mathurin/anaconda3/envs/test/lib/python3.9/site-packages/numpy/distutils/misc_util.py", line 982, in get_subpackage
        config = self._get_configuration_from_setup_py(
      File "/home/mathurin/anaconda3/envs/test/lib/python3.9/site-packages/numpy/distutils/misc_util.py", line 924, in _get_configuration_from_setup_py
        config = setup_module.configuration(*args)
      File "lightning/setup.py", line 27, in configuration
        cythonize_extensions(top_path, config)
      File "lightning/setup.py", line 11, in cythonize_extensions
        raise ModuleNotFoundError(
    ModuleNotFoundError: Please install Cython in order to build a lightning from source.
    ----------------------------------------
WARNING: Discarding git+https://github.com/scikit-learn-contrib/lightning.git. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
Traceback (most recent call last):
  File "/home/mathurin/anaconda3/envs/test/bin/benchopt", line 33, in <module>
    sys.exit(load_entry_point('benchopt', 'console_scripts', 'benchopt')())
  File "/home/mathurin/anaconda3/envs/test/lib/python3.9/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/mathurin/anaconda3/envs/test/lib/python3.9/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/mathurin/anaconda3/envs/test/lib/python3.9/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/mathurin/anaconda3/envs/test/lib/python3.9/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/mathurin/anaconda3/envs/test/lib/python3.9/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/mathurin/workspace/benchopt/benchopt/cli/main.py", line 277, in install
    benchmark.install_all_requirements(
  File "/home/mathurin/workspace/benchopt/benchopt/benchmark.py", line 235, in install_all_requirements
    install_in_conda_env(
  File "/home/mathurin/workspace/benchopt/benchopt/utils/conda_env_cmd.py", line 195, in install_in_conda_env
    _run_shell_in_conda_env(
  File "/home/mathurin/workspace/benchopt/benchopt/utils/shell_cmd.py", line 130, in _run_shell_in_conda_env
    return _run_shell(
  File "/home/mathurin/workspace/benchopt/benchopt/utils/shell_cmd.py", line 68, in _run_shell
    raise RuntimeError(raise_on_error.format(output=output))
RuntimeError: Failed to conda install packages ('pip:libsvmdata', 'pip:git+https://github.com/scikit-learn-contrib/lightning.git')
Error:
```