### PR TITLE
Add python_glmnet solver

### DIFF
--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -13,9 +13,9 @@ class Dataset(BaseDataset):
     parameters = {
         'n_samples, n_features': [
             (100, 5_000),
-            (100, 10_000)
+            # (100, 10_000)
         ],
-        'rho': [0, 0.6],
+        'rho': [0.6],
     }
 
     def __init__(self, n_samples=10, n_features=50, rho=0, random_state=27):

--- a/debug_glmnet.py
+++ b/debug_glmnet.py
@@ -1,0 +1,19 @@
+from benchopt.datasets.simulated import make_correlated_data
+from sklearn.linear_model import ElasticNet
+import glmnet
+from numpy.linalg import norm
+import numpy as np
+
+X, y, _ = make_correlated_data(100, 5000, rho=0.6, random_state=27)
+alpha_max = norm(X.T @ y, ord=np.inf) / len(y)
+
+
+clf = ElasticNet(alpha=alpha_max / 2, l1_ratio=1,
+                 fit_intercept=False, tol=1e-10).fit(X, y)
+
+
+clf2 = glmnet.ElasticNet(alpha=1, lambda_path=[
+                         alpha_max, alpha_max/2], standardize=False, fit_intercept=False, tol=1e-10, max_iter=10000).fit(X, y)
+
+
+print(norm(clf.coef_ - clf2.coef_) / norm(clf.coef_))

--- a/objective.py
+++ b/objective.py
@@ -9,7 +9,7 @@ class Objective(BaseObjective):
 
     parameters = {
         'reg': [0.05, .1, .5],
-        'fit_intercept': [True, False]
+        'fit_intercept': [False]
     }
 
     def __init__(self, reg=.1, fit_intercept=False):

--- a/solvers/python_glmnet.py
+++ b/solvers/python_glmnet.py
@@ -1,0 +1,46 @@
+from benchopt import BaseSolver
+from benchopt import safe_import_context
+from benchopt import stopping_criterion
+from benchopt.stopping_criterion import SufficientProgressCriterion
+
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    import glmnet
+
+
+class Solver(BaseSolver):
+    name = "python_glmnet"
+
+    install_cmd = 'conda'
+    requirements = ['glmnet']
+    references = [
+        'J. Friedman, T. J. Hastie and R. Tibshirani, "Regularization paths '
+        'for generalized linear models via coordinate descent", '
+        'J. Stat. Softw., vol. 33, no. 1, pp. 1-22, NIH Public Access (2010)'
+    ]
+
+    stopping_criterion = SufficientProgressCriterion(
+        patience=10, strategy='tolerance')
+    support_sparse = False
+
+    def skip(self, X, y, lmbd, fit_intercept):
+        if fit_intercept:
+            return True, f"{self.name} does not handle fit_intercept"
+
+        return False, None
+
+    def set_objective(self, X, y, lmbd, fit_intercept):
+        self.X, self.y, self.lmbd = X, y, lmbd
+        self.lmbd_max = max(abs(X.T @ y))
+        self.fit_intercept = fit_intercept
+        self.clf = glmnet.ElasticNet(
+            alpha=1, lambda_path=[self.lmbd_max / len(y), lmbd / len(y)],
+            standardize=False, max_iter=1_000_000, fit_intercept=False)
+
+    def run(self, tol):
+        self.clf.tol = tol ** 2.3
+        self.clf.fit(self.X, self.y)
+
+    def get_result(self):
+        return self.clf.coef_


### PR DESCRIPTION
This is an attempt at using the conda installable Python wrapper for GLMNET. This should allow us to remove the overhead of the rpy2 call.

I don't get the same results as sklearn in the `debug_glmnet.py` script. For smaller values of n_features like 100, 200, 300, it worked.

@jolars if you want to have a look...