### PR TITLE
ENH: support sparse X for glmnet

### DIFF
--- a/datasets/libsvm.py
+++ b/datasets/libsvm.py
@@ -12,7 +12,7 @@ class Dataset(BaseDataset):
     name = "libsvm"
 
     parameters = {
-        'dataset': ["bodyfat", "leukemia"],
+        'dataset': ["bodyfat", "leukemia", "rcv1.binary"],
     }
 
     install_cmd = 'conda'

--- a/objective.py
+++ b/objective.py
@@ -8,7 +8,7 @@ class Objective(BaseObjective):
     name = "Lasso Regression"
 
     parameters = {
-        'fit_intercept': [True, False]
+        'fit_intercept': [True, False],
         'reg': [.5, .1, .05],
     }
 

--- a/objective.py
+++ b/objective.py
@@ -8,8 +8,8 @@ class Objective(BaseObjective):
     name = "Lasso Regression"
 
     parameters = {
-        'reg': [0.05, .1, .5],
         'fit_intercept': [True, False]
+        'reg': [.5, .1, .05],
     }
 
     def __init__(self, reg=.1, fit_intercept=False):

--- a/solvers/glmnet.py
+++ b/solvers/glmnet.py
@@ -1,12 +1,13 @@
-from benchopt import BaseSolver
-from benchopt import safe_import_context
-
+from benchopt import BaseSolver, safe_import_context
+from benchopt.runner import INFINITY
+from benchopt.stopping_criterion import SufficientProgressCriterion
 
 with safe_import_context() as import_ctx:
     import numpy as np
+    from scipy import sparse
 
     from rpy2 import robjects
-    from rpy2.robjects import numpy2ri
+    from rpy2.robjects import numpy2ri, packages
     from benchopt.helpers.r_lang import import_rpackages
 
     # Setup the system to allow rpy2 running
@@ -18,14 +19,18 @@ class Solver(BaseSolver):
     name = "glmnet"
 
     install_cmd = 'conda'
-    requirements = ['r-base', 'rpy2', 'r-glmnet']
+    requirements = ['r-base', 'rpy2', 'r-glmnet', 'r-matrix']
     references = [
         'J. Friedman, T. J. Hastie and R. Tibshirani, "Regularization paths '
         'for generalized linear models via coordinate descent", '
         'J. Stat. Softw., vol. 33, no. 1, pp. 1-22, NIH Public Access (2010)'
     ]
-    stop_strategy = 'iteration'
-    support_sparse = False
+    support_sparse = True
+
+    stopping_criterion = SufficientProgressCriterion(
+        patience=7, eps=1e-38, strategy='tolerance')
+    # We use the tolerance strategy because if maxit is too low and glmnet
+    # convergence check fails, it returns an empty model
 
     def skip(self, X, y, lmbd, fit_intercept):
         # XXX - glmnet support intercept, adapt the API
@@ -35,21 +40,50 @@ class Solver(BaseSolver):
         return False, None
 
     def set_objective(self, X, y, lmbd, fit_intercept):
-        self.X, self.y, self.lmbd = X, y, lmbd
+        if sparse.issparse(X):
+            r_Matrix = packages.importr("Matrix")
+            X = X.tocoo()
+            self.X = r_Matrix.sparseMatrix(
+                i=robjects.IntVector(X.row + 1),
+                j=robjects.IntVector(X.col + 1),
+                x=robjects.FloatVector(X.data),
+                dims=robjects.IntVector(X.shape)
+            )
+        else:
+            self.X = X
+        self.y, self.lmbd = y, lmbd
         self.fit_intercept = fit_intercept
 
         self.lmbd_max = np.max(np.abs(X.T @ y))
         self.glmnet = robjects.r['glmnet']
 
-    def run(self, n_iter):
-        fit_dict = {"lambda.min.ratio": self.lmbd / self.lmbd_max}
+    def run(self, tol):
+        # Even if maxit=0, glmnet can return non zero coefficients. To get the
+        # initial point on the curve, we set tol=0: this way, glmnet
+        # convergence check fails, and rather than returning the current
+        # iterate, it returns a 0 model.
+        if tol == INFINITY:
+            maxit = 0
+            thresh = 0
+        else:
+            maxit = 1_000_000
+            # we need thresh to decay fast, otherwise the objective curve can
+            # plateau before convergence
+            thresh = tol ** 1.8
+
+        # We fit with a single lambda because when computing a path, glmnet
+        # early stops the path based on an uncontrollable criterion. Fitting
+        # with a single lambda may be suboptimal if it is small, but there is
+        # no other way to force glmnet to solve for a prescribed lambda.
+        fit_dict = {"lambda": self.lmbd / len(self.y)}
+
         glmnet_fit = self.glmnet(self.X, self.y, intercept=False,
-                                 standardize=False, maxit=n_iter,
-                                 thresh=1e-14, **fit_dict)
+                                 standardize=False, maxit=maxit,
+                                 thresh=thresh, **fit_dict)
         results = dict(zip(glmnet_fit.names, list(glmnet_fit)))
         as_matrix = robjects.r['as']
         coefs = np.array(as_matrix(results["beta"], "matrix"))
-        self.w = coefs[:, -1]
+        self.w = coefs.flatten()
 
     def get_result(self):
         return self.w


### PR DESCRIPTION
I added rcv1.binary to the datasets, it seems to work, and quite fast, with the policy of #46 

![image](https://user-images.githubusercontent.com/8993218/145214925-3a3aee2b-b3b2-4c50-8774-4b7882989c7f.png)

However on finance I get a huge memory consumption, + 18 Gb:
![image](https://user-images.githubusercontent.com/8993218/145215746-2064e34f-f157-48fb-8c4d-56fbd73d8dd6.png)

