### PR TITLE
set permute=False in lightning to fix convergence

### DIFF
--- a/solvers/lightning.py
+++ b/solvers/lightning.py
@@ -36,7 +36,7 @@ class Solver(BaseSolver):
 
         self.clf = CDRegressor(
             loss='squared', penalty='l1', C=.5, alpha=self.lmbd,
-            tol=1e-15
+            tol=1e-15, random_state=0, permute=False
         )
 
     def run(self, n_iter):


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/8993218/146672282-c104c276-68fd-4e5f-969e-26c17bd87bf6.png)
After:
![image](https://user-images.githubusercontent.com/8993218/146672293-277fe501-ee62-40eb-a6c0-a229df012844.png)


I also set the random_state. I think it's overkill for now to expose it.