### PR TITLE
remove scaling by lambda in gap

### DIFF
--- a/objective.py
+++ b/objective.py
@@ -30,10 +30,9 @@ class Objective(BaseObjective):
             diff -= intercept
         # compute primal objective and duality gap
         p_obj = .5 * diff.dot(diff) + self.lmbd * abs(beta).sum()
-        theta = diff / self.lmbd
-        theta /= norm(self.X.T @ theta, ord=np.inf)
-        d_obj = (norm(self.y) ** 2 / 2. - self.lmbd ** 2 *
-                 norm(self.y / self.lmbd - theta) ** 2 / 2)
+        scaling = max(1, norm(self.X.T @ diff, ord=np.inf) / self.lmbd)
+        d_obj = (norm(self.y) ** 2 / 2.
+                 - norm(self.y - diff / scaling) ** 2 / 2)
         return dict(value=p_obj,
                     support_size=(beta != 0).sum(),
                     duality_gap=p_obj - d_obj,)


### PR DESCRIPTION
It was done in the Gap Safe paper to have the same dual contraint set when lambda varies, but here it's just simpler to have the regular constraint 
![image](https://user-images.githubusercontent.com/8993218/158787897-5bae0e2a-9869-42b4-a233-4bb03242dadd.png)

Thus we pick
![image](https://user-images.githubusercontent.com/8993218/158787924-7837830b-92e1-4f68-b9d8-281def31c617.png)


Also @agramfort note that in the standard Fenchel-Rockafellar duality one has 
![image](https://user-images.githubusercontent.com/8993218/158788035-c2acbea2-8392-4b5a-a3f0-26f90825ae3a.png)

and 
![image](https://user-images.githubusercontent.com/8993218/158788056-f3b00384-c3b2-4fc6-ab79-8af2b9038753.png)
 
 instead of the opposite (`theta = y - X @ w`) as is done in the Gap paper.
 
 Of potential interest for @lorentzenchr too
 
 
 The value of the gap is unchanged in my experiments:
 |main|this pr|
 |---|---| 
 |![image](https://user-images.githubusercontent.com/8993218/158789981-56739ecb-6332-47e5-acce-ab980f840f01.png)|![image](https://user-images.githubusercontent.com/8993218/158790385-01427cb0-0677-4860-8054-94a217717318.png)|