### PR TITLE
coef name harmonization: w instead of beta, to match doc

### DIFF
--- a/solvers/celer.py
+++ b/solvers/celer.py
@@ -45,7 +45,7 @@ class Solver(BaseSolver):
 
     def get_result(self):
 
-        beta = self.lasso.coef_.flatten()
+        w = self.lasso.coef_.flatten()
         if self.fit_intercept:
-            beta = np.r_[beta, self.lasso.intercept_]
-        return beta
+            w = np.r_[w, self.lasso.intercept_]
+        return w

--- a/solvers/cyanure.py
+++ b/solvers/cyanure.py
@@ -41,8 +41,8 @@ class Solver(BaseSolver):
                         **self.solver_parameter)
 
     def get_result(self):
-        beta = self.solver.get_weights()
+        w = self.solver.get_weights()
         if self.fit_intercept:
-            beta, intercept = beta
-            beta = np.r_[beta.flatten(), intercept]
-        return beta
+            w, intercept = w
+            w = np.r_[w.flatten(), intercept]
+        return w

--- a/solvers/glmnet.py
+++ b/solvers/glmnet.py
@@ -76,9 +76,9 @@ class Solver(BaseSolver):
         results = dict(zip(glmnet_fit.names, list(glmnet_fit)))
         as_matrix = robjects.r['as']
         coefs = np.array(as_matrix(results["beta"], "matrix"))
-        beta = coefs.flatten()
+        w = coefs.flatten()
 
-        self.w = np.r_[beta, results["a0"]] if self.fit_intercept else beta
+        self.w = np.r_[w, results["a0"]] if self.fit_intercept else w
 
     def get_result(self):
         return self.w

--- a/solvers/glum.py
+++ b/solvers/glum.py
@@ -48,7 +48,7 @@ class Solver(BaseSolver):
         self.model.fit(self.X, self.y)
 
     def get_result(self):
-        beta = self.model.coef_.flatten()
+        w = self.model.coef_.flatten()
         if self.fit_intercept:
-            beta = np.r_[beta, self.model.intercept_]
-        return beta
+            w = np.r_[w, self.model.intercept_]
+        return w

--- a/solvers/julia_pgd.py
+++ b/solvers/julia_pgd.py
@@ -43,7 +43,7 @@ class Solver(JuliaSolver):
         self.solve_lasso = jl.include(JULIA_SOLVER_FILE)
 
     def run(self, n_iter):
-        self.beta = self.solve_lasso(self.X, self.y, self.lmbd, n_iter)
+        self.w = self.solve_lasso(self.X, self.y, self.lmbd, n_iter)
 
     def get_result(self):
-        return self.beta.ravel()
+        return self.w.ravel()

--- a/solvers/lightning.py
+++ b/solvers/lightning.py
@@ -44,7 +44,7 @@ class Solver(BaseSolver):
         self.clf.fit(self.X, self.y)
 
     def get_result(self):
-        beta = self.clf.coef_.flatten()
+        w = self.clf.coef_.flatten()
         if self.fit_intercept:
-            beta = np.r_[beta, self.clf.intercept_]
-        return beta
+            w = np.r_[w, self.clf.intercept_]
+        return w

--- a/solvers/sklearn.py
+++ b/solvers/sklearn.py
@@ -37,7 +37,7 @@ class Solver(BaseSolver):
         self.clf.fit(self.X, self.y)
 
     def get_result(self):
-        beta = self.clf.coef_.flatten()
+        w = self.clf.coef_.flatten()
         if self.fit_intercept:
-            beta = np.r_[beta, self.clf.intercept_]
-        return beta
+            w = np.r_[w, self.clf.intercept_]
+        return w


### PR DESCRIPTION
This PR intends to harmonize the name of the coefficients between available lasso solvers for clarity and future maintenance.
Also this is to comply with the doc TeX formulation:
https://benchopt.github.io/index.html#quickstart-command-line-usage-on-the-lasso-benchmark
