### PR TITLE
FIX correct alpha_max when using intercept

### DIFF
--- a/objective.py
+++ b/objective.py
@@ -38,7 +38,10 @@ class Objective(BaseObjective):
                     duality_gap=p_obj - d_obj,)
 
     def _get_lambda_max(self):
-        return abs(self.X.T.dot(self.y)).max()
+        if self.fit_intercept:
+            return abs(self.X.T @ (self.y - self.y.mean())).max()
+        else:
+            return abs(self.X.T.dot(self.y)).max()
 
     def to_dict(self):
         return dict(X=self.X, y=self.y, lmbd=self.lmbd,


### PR DESCRIPTION
Before (alpha_max is too high, alpha_max / 2 is greater than the correct alpha_max hence the sovler doesn't move):
![image](https://user-images.githubusercontent.com/8993218/161049350-3f6b25dc-497b-4922-b09f-ff5d83dc0b26.png)


After:
![image](https://user-images.githubusercontent.com/8993218/161049385-24714588-2eb5-4b37-a02c-b959d959a3cb.png)
