### PR TITLE
FIX support n_iter = 0 for celer after sklearn breaking change

### DIFF
--- a/solvers/celer.py
+++ b/solvers/celer.py
@@ -35,8 +35,16 @@ class Solver(BaseSolver):
         )
 
     def run(self, n_iter):
-        self.lasso.max_iter = n_iter
-        self.lasso.fit(self.X, self.y)
+        if n_iter == 0:
+            self.coef = np.zeros([self.X.shape[1] + self.fit_intercept])
+        else:
+            self.lasso.max_iter = n_iter
+            self.lasso.fit(self.X, self.y)
+
+            coef = self.lasso.coef_.flatten()
+            if self.fit_intercept:
+                coef = np.r_[coef, self.lasso.intercept_]
+            self.coef = coef
 
     @staticmethod
     def get_next(previous):
@@ -44,8 +52,4 @@ class Solver(BaseSolver):
         return previous + 1
 
     def get_result(self):
-
-        beta = self.lasso.coef_.flatten()
-        if self.fit_intercept:
-            beta = np.r_[beta, self.lasso.intercept_]
-        return beta
+        return self.coef

--- a/solvers/sklearn.py
+++ b/solvers/sklearn.py
@@ -29,7 +29,7 @@ class Solver(BaseSolver):
 
         n_samples = self.X.shape[0]
         self.lasso = Lasso(alpha=self.lmbd/n_samples,
-                         fit_intercept=fit_intercept, tol=0)
+                           fit_intercept=fit_intercept, tol=0)
         warnings.filterwarnings('ignore', category=ConvergenceWarning)
 
     def run(self, n_iter):

--- a/solvers/sklearn.py
+++ b/solvers/sklearn.py
@@ -33,11 +33,16 @@ class Solver(BaseSolver):
         warnings.filterwarnings('ignore', category=ConvergenceWarning)
 
     def run(self, n_iter):
-        self.clf.max_iter = n_iter
-        self.clf.fit(self.X, self.y)
+        if n_iter == 0:
+            self.coef = np.zeros([self.X.shape[1] + self.fit_intercept])
+        else:
+            self.lasso.max_iter = n_iter
+            self.lasso.fit(self.X, self.y)
+
+            coef = self.lasso.coef_.flatten()
+            if self.fit_intercept:
+                coef = np.r_[coef, self.lasso.intercept_]
+            self.coef = coef
 
     def get_result(self):
-        beta = self.clf.coef_.flatten()
-        if self.fit_intercept:
-            beta = np.r_[beta, self.clf.intercept_]
-        return beta
+        return self.coef

--- a/solvers/sklearn.py
+++ b/solvers/sklearn.py
@@ -28,7 +28,7 @@ class Solver(BaseSolver):
         self.fit_intercept = fit_intercept
 
         n_samples = self.X.shape[0]
-        self.clf = Lasso(alpha=self.lmbd/n_samples,
+        self.lasso = Lasso(alpha=self.lmbd/n_samples,
                          fit_intercept=fit_intercept, tol=0)
         warnings.filterwarnings('ignore', category=ConvergenceWarning)
 


### PR DESCRIPTION
sklearn now checks in Lasso.fit() that max_iter is > 0, so the current code breaks for solvers using this method (sklearn, celer, skglm).

Here is a fix for celer. @tomMoral if it LGTY I use it in sklearn and skglm too. 