### PR TITLE
add snapml solver

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,12 @@ jobs:
 
     - run: conda info
 
+     # see https://github.com/benchopt/benchmark_logreg_l1/issues/20
+    - name: Install OpenMP
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install libomp
+
     - name: Install benchopt and its dependencies
       run: |
         conda info
@@ -58,6 +64,7 @@ jobs:
 
     - name: Test
       run: |
+        export OMP_NUM_THREADS=1
         benchopt test . --env-name bench_test_env -vl
         benchopt test . --env-name bench_test_env -vl --skip-install
 

--- a/solvers/snapml.py
+++ b/solvers/snapml.py
@@ -15,7 +15,7 @@ class Solver(BaseSolver):
 
     parameters = {"gpu": [True, False]}
 
-    def skip(self, X, y, lmbd):
+    def skip(self, X, y, lmbd, fit_intercept):
         if self.gpu and _get_cuda_version() is None:
             return True, "snapml[gpu=True] needs a GPU to run"
         return False, None

--- a/solvers/snapml.py
+++ b/solvers/snapml.py
@@ -1,0 +1,44 @@
+from benchopt import BaseSolver, safe_import_context
+from benchopt.utils.sys_info import _get_cuda_version
+
+cuda_version = _get_cuda_version()
+
+with safe_import_context() as import_ctx:
+    from snapml import LinearRegression
+    import numpy as np
+
+
+class Solver(BaseSolver):
+    name = "snapml"
+
+    install_cmd = "conda"
+    requirements = ["pip:snapml"]
+
+    def set_objective(self, X, y, lmbd, fit_intercept):
+        self.X, self.y, self.lmbd = X, y, lmbd
+        self.fit_intercept = fit_intercept
+        self.use_gpu = cuda_version is not None
+
+        self.clf = LinearRegression(
+            fit_intercept=self.fit_intercept,
+            regularizer=self.lmbd,
+            penalty="l1",
+            tol=1e-12,
+            dual=False,
+            use_gpu=self.use_gpu,
+        )
+
+    def run(self, n_iter):
+        if n_iter == 0:
+            self.coef = np.zeros([self.X.shape[1] + self.fit_intercept])
+            return
+
+        self.clf.max_iter = n_iter
+        self.clf.fit(self.X, self.y)
+        coef = self.clf.coef_.flatten()
+        if self.fit_intercept:
+            coef = np.r_[coef, self.clf.intercept_]
+        self.coef = coef
+
+    def get_result(self):
+        return self.coef

--- a/solvers/snapml.py
+++ b/solvers/snapml.py
@@ -13,7 +13,7 @@ class Solver(BaseSolver):
     install_cmd = "conda"
     requirements = ["pip:snapml"]
 
-    parameters = {"gpu": [True, False]}
+    parameters = {"gpu": [False, True]}
 
     def skip(self, X, y, lmbd, fit_intercept):
         if self.gpu and _get_cuda_version() is None:

--- a/test_config.py
+++ b/test_config.py
@@ -1,5 +1,5 @@
 import sys
-
+from benchopt.utils.sys_info import _get_cuda_version
 import pytest
 
 
@@ -21,3 +21,7 @@ def check_test_solver_install(solver_class):
             'Modopt breaks other package installation by changing '
             'numpy version. Skipping for now.'
         )
+
+    if solver_class.name.lower() == "snapml[gpu=True]".lower():
+        if _get_cuda_version() is None:
+            pytest.skip("snapml[gpu=True] needs a GPU to run")

--- a/test_config.py
+++ b/test_config.py
@@ -1,8 +1,6 @@
 import sys
 import pytest
 
-from benchopt.utils.sys_info import _get_cuda_version
-
 
 def check_test_solver_install(solver_class):
 
@@ -22,7 +20,3 @@ def check_test_solver_install(solver_class):
             'Modopt breaks other package installation by changing '
             'numpy version. Skipping for now.'
         )
-
-    if solver_class.name.lower() == "snapml[gpu=True]".lower():
-        if _get_cuda_version() is None:
-            pytest.skip("snapml[gpu=True] needs a GPU to run")

--- a/test_config.py
+++ b/test_config.py
@@ -1,6 +1,7 @@
 import sys
-from benchopt.utils.sys_info import _get_cuda_version
 import pytest
+
+from benchopt.utils.sys_info import _get_cuda_version
 
 
 def check_test_solver_install(solver_class):


### PR DESCRIPTION
Fixes #83 by adding snapml solver

This solver is not good when intercept is True or with small datasets, but for example with rcv1:
One example of run 
![Capture d’écran de 2022-05-09 18-27-53](https://user-images.githubusercontent.com/57089823/167455208-3ff50db0-78df-4b96-8bbc-cf6a06ce17f2.png)
