### PR TITLE
Fix for noncvx-pro solver on sparse matrix

### DIFF
--- a/solvers/noncvx_pro.py
+++ b/solvers/noncvx_pro.py
@@ -5,7 +5,6 @@ with safe_import_context() as import_ctx:
     import numpy as np
     from numpy.linalg import norm
     import scipy.optimize as sciop
-    from scipy.sparse import issparse
 
 
 class Solver(BaseSolver):
@@ -19,9 +18,6 @@ class Solver(BaseSolver):
     def skip(self, X, y, lmbd, fit_intercept):
         if fit_intercept:
             return True, f"{self.name} does not handle fit_intercept"
-        # XXX: make this solver work with sparse matrices.
-        if issparse(X):
-            return True, f"{self.name} does not support sparse design matrices"
         return False, None
 
     def run(self, n_iter):

--- a/solvers/noncvx_pro.py
+++ b/solvers/noncvx_pro.py
@@ -28,7 +28,7 @@ class Solver(BaseSolver):
 
         if n_samples < n_features:
             def u_opt(v):
-                S = X @ np.diag(v**2) @ X.T + lmbd * np.eye(n_samples)
+                S = X * v**2 @ X.T + lmbd * np.eye(n_samples)
                 return v * (X.T @ np.linalg.solve(S, y))
 
             def nabla_f(v):


### PR DESCRIPTION
We want to fix noncvx-pro solver for sparse matrix to reproduce the results obtained in original paper, Smooth Bilevel Programming for Sparse Regularization (Poon and Peyré) on leukemia. For the moment, solver is slow. 

See
<img width="1179" alt="Capture d’écran 2022-05-11 à 10 13 14" src="https://user-images.githubusercontent.com/40163547/167801579-76011c29-4805-462d-94e8-4e67510d3f5a.png">


in comparison to this
<img width="541" alt="Capture d’écran 2022-05-11 à 10 11 55" src="https://user-images.githubusercontent.com/40163547/167801391-e92f5fc6-f6e7-41cd-889f-de5b7694a1f1.png">

