### PR TITLE
FIX noncvx-pro: use same lbfgs options as in original paper

### DIFF
--- a/solvers/noncvx_pro.py
+++ b/solvers/noncvx_pro.py
@@ -65,7 +65,7 @@ class Solver(BaseSolver):
                 g = u * (Cx - Xty) / lmbd + v
                 return f, g
 
-        opts = {'gtol': 1e-8, 'maxiter': n_iter, 'maxcor': 5, 'ftol': 0}
+        opts = {'gtol': 1e-30, 'maxiter': n_iter, 'maxcor': 5, 'ftol': 1e-30}
         u0 = np.ones(n_features)
 
         lbfgs_res = sciop.minimize(


### PR DESCRIPTION
Converge is obtained by setting LBFGS parameters `g_tol` and `f_tol` to 1e-30 as done in the [original implementation](https://github.com/gpeyre/numerical-tours/blob/master/python/optim_7_noncvx_pro.ipynb).
This change doesn't seem to impact the convergence speed of the solver.

As a side-note, should we discuss the **initialization u0**? Here we set it to the all-ones vector, which gives a considerably different initial cost function value compared to other solvers (initialized at the all-zeros vector)?