### PR TITLE
FIX cuML solver working with sparse matrices:

### DIFF
--- a/solvers/cuml.py
+++ b/solvers/cuml.py
@@ -9,8 +9,12 @@ with safe_import_context() as import_ctx:
     else:
         raise ImportError("cuml solver needs a nvidia GPU.")
 
-    import cudf
     import numpy as np
+    from scipy import sparse
+
+    import cudf
+    import cupy as cp
+    import cupyx.scipy.sparse as cusparse
     from cuml.linear_model import Lasso
 
 
@@ -21,7 +25,7 @@ class Solver(BaseSolver):
     requirements = [
         "rapidsai::rapids",
         f"nvidia::cudatoolkit={cuda_version}",
-        "dask-sql",
+        "dask-sql", "cupy"
     ] if cuda_version is not None else []
 
     parameters = {
@@ -41,7 +45,15 @@ class Solver(BaseSolver):
 
     def set_objective(self, X, y, lmbd, fit_intercept):
         self.X, self.y, self.lmbd = X, y, lmbd
-        self.X = cudf.DataFrame(self.X)
+        if sparse.issparse(X):
+            if sparse.isspmatrix_csc(X):
+                self.X = cusparse.csc_matrix(X)
+            elif sparse.isspmatrix_csr(X):
+                self.X = cusparse.csr_matrix(X)
+            else:
+                raise ValueError("Non suported sparse format")
+        else:
+            self.X = cudf.DataFrame(self.X.astype(np.float32))
         self.y = cudf.Series(self.y)
         self.fit_intercept = fit_intercept
 
@@ -58,7 +70,13 @@ class Solver(BaseSolver):
         self.result_lasso = self.lasso.fit(self.X, self.y)
 
     def get_result(self):
-        if self.fit_intercept:
-            return np.r_[self.result_lasso.coef_, self.result_lasso.intercept_]
+        if isinstance(self.clf.coef_, cp.ndarray):
+            coef = self.clf.coef_.get().flatten()
+            if self.clf.fit_intercept:
+                coef = np.r_[coef, self.clf.intercept_.get()]
         else:
-            return self.result_lasso.coef_
+            coef = self.clf.coef_.to_numpy().flatten()
+            if self.clf.fit_intercept:
+                coef = np.r_[coef, self.clf.intercept_.to_numpy()]
+
+        return coef


### PR DESCRIPTION
Just found out that we simply need to make the conversion to `cupy` sparse matrix to get it running.
Not tested yet, I will on logreg and let you know if this works well.