### PR TITLE
remove modopt test skip

### DIFF
--- a/test_config.py
+++ b/test_config.py
@@ -15,14 +15,6 @@ def check_test_solver_install(solver_class):
     if 'julia' in solver_class.name.lower():
         pytest.xfail('Julia install from conda fails currently.')
 
-    # ModOpt install change numpy version, breaking celer install.
-    # See CEA-COSMIC/ModOpt#144. Skipping for now
-    if ('modopt' in solver_class.name.lower()):
-        pytest.skip(
-            'Modopt breaks other package installation by changing '
-            'numpy version. Skipping for now.'
-        )
-
     if "cuml" in solver_class.name.lower():
         if sys.platform == "darwin":
             pytest.xfail("Cuml is not supported on MacOS.")


### PR DESCRIPTION
We have released wheels built with numpy 1.20 for celer 0.7.1, so modopt changing numpy version after celer install should no longer be an issue :crossed_fingers: 