### PR TITLE
MNT - fix ``cuml`` solver requirements

### DIFF
--- a/solvers/cuml.py
+++ b/solvers/cuml.py
@@ -25,8 +25,8 @@ class Solver(BaseSolver):
 
     install_cmd = "conda"
     requirements = [
-        "rapidsai::rapids",
-        f"nvidia::cudatoolkit={cuda_version}",
+        "rapidsai:rapids",
+        f"nvidia:cudatoolkit={cuda_version}",
         "dask-sql", "cupy"
     ] if cuda_version is not None else []
 


### PR DESCRIPTION
After https://github.com/benchopt/benchopt/pull/483,
conda channels are specified with a single colon.